### PR TITLE
add missing quotes to prevent word splitting

### DIFF
--- a/scripts/xdg-utils-common.in
+++ b/scripts/xdg-utils-common.in
@@ -62,9 +62,9 @@ desktop_file_to_binary()
         if [ "${desktop#*-}" != "$desktop" ]; then
             vendor=${desktop%-*}
             app=${desktop#*-}
-            if [ -r $dir/applications/$vendor/$app ]; then
+            if [ -r "$dir/applications/$vendor/$app" ]; then
                 file_path=$dir/applications/$vendor/$app
-            elif [ -r $dir/applnk/$vendor/$app ]; then
+            elif [ -r "$dir/applnk/$vendor/$app" ]; then
                 file_path=$dir/applnk/$vendor/$app
             fi
         fi


### PR DESCRIPTION
When opening links with xdg-open using Firefox Developer Edition, errors are printed:
/usr/bin/xdg-mime: line 323: [: too many arguments
/usr/bin/xdg-mime: line 325: [: too many arguments

This happens because the spaces in the browser name lead to word splitting for the unquoted variables $vendor and $app. My patch fixes the problem.