### PR TITLE
fix xdg-open + lxde url open issue

### DIFF
--- a/scripts/xdg-open.in
+++ b/scripts/xdg-open.in
@@ -451,7 +451,7 @@ open_lxde()
 {
 
     # pcmanfm only knows how to handle file:// urls and filepaths, it seems.
-    if pcmanfm --help >/dev/null 2>&1 -a is_file_url_or_path "$1"; then
+    if ([ -x /usr/bin/pcmanfm ]  && is_file_url_or_path "$1" ); then
         local file="$(file_url_to_path "$1")"
 
         # handle relative paths


### PR DESCRIPTION
After new update I got an issue when _any_ http(s) links was redirected to open with pcmanfm.

![2018-05-23-235118_922x225_scrot](https://user-images.githubusercontent.com/1037402/40452079-4cf281f8-5ee9-11e8-9744-c70768ba37d2.png)
