### PR TITLE
Quote $browser variable when using XDG_BROWSER env var

### DIFF
--- a/scripts/xdg-open.in
+++ b/scripts/xdg-open.in
@@ -391,7 +391,7 @@ open_envvar()
             # URIs don't have IFS characters spaces anyway.
             has_single_argument $1 && $(printf "$browser" "$1")
         else
-            $browser "$1"
+            "$browser" "$1"
         fi
 
         if [ $? -eq 0 ]; then


### PR DESCRIPTION
Bug fix - when using xdg-open on WSL2, often the XDG_BROWSER env var will contain spaces: 

```
export XDG_BROWSER="/c/Program Files/Mozilla Firefox/firefox.exe"
```

If the `$browser` env var is not quoted, the command

`"/c/Program" "Files/Mozilla" "Firefox/firefox.exe" "https://www.google.com"` is run instead of `"/c/Program Files/Mozilla Firefox/firefox.exe" "https://www.google.com"`