### PR TITLE
Use updated URL in README

### DIFF
--- a/README
+++ b/README
@@ -64,7 +64,7 @@ USE:
 of the operating system, we recommend that you package the scripts
 that your application needs along with your product as a fallback. For
 this purpose please obtain the original version of the xdg-utils from
-http://portland.freedesktop.org. The xdg-utils scripts that are
+[freedesktop.org](https://www.freedesktop.org/wiki/Software/xdg-utils/). The xdg-utils scripts that are
 distributed by operating systems vendors may have been tuned for their
 particular operating system and may not work on the same broad variety
 of operating systems as the original version.


### PR DESCRIPTION
The old URL in the README (https://portland.freedesktop.org/) goes to this page:
![image](https://user-images.githubusercontent.com/23198134/103928711-3b285380-50ea-11eb-9d70-505dbf35897c.png)

That page then links to https://www.freedesktop.org/wiki/Software/xdg-utils/.

This PR is to update the link in the README to directly point to the desired URL.