### PR TITLE
Fix lxqt-sudo call in su_lxqt

### DIFF
--- a/scripts/xdg-su.in
+++ b/scripts/xdg-su.in
@@ -84,7 +84,7 @@ su_lxqt()
     if [ $? -eq 0 ] ; then
         if [ -z "$user" ] ; then
              # -s option runs as su rather then sudo
-             $LXQTSU -s "$cmd"
+             $LXQTSU -s $cmd
         else
              # lxqt-sudo does not support specifying a user
              su_generic


### PR DESCRIPTION
This commit removes the quotes around $cmd for the lxqt-sudo call.

The lxqt-sudo command does not take a single string as its
command argument. See the usage text:
```bash
$ lxqt-sudo --help
Usage: lxqt-sudo option [command [arguments...]]
...
```

and compare to, e.g., gnomesu:
```bash
$ gnomesu --help
Usage:
  gnomesu [OPTION…]
...
Application Options:
  -c, --command=COMMAND     Pass the command to execute as one single string.
```
In the current state xdg-su errors on lxqt-sudo call for any command that includes arguments similar to:
```bash
$  lxqt-sudo -s "ls /tmp"

bash: line 1: /home/jaredd/workspace/repos/xdg-utils/scripts/ls /tmp: No such file or directory
```
The corrected call without quotes:
```bash
$ lxqt-sudo -s ls /tmp

grilo-plugin-cache-0IT4M1
...
```