### PR TITLE
xdg-open: add $XDG_OPEN_USE_PORTAL env var

### DIFF
--- a/scripts/xdg-open.in
+++ b/scripts/xdg-open.in
@@ -508,6 +508,10 @@ if [ x"$DE" = x"" ]; then
     DE=generic
 fi
 
+if [ -n "$XDG_OPEN_USE_PORTAL"  ]; then
+    DE=flatpak
+fi
+
 DEBUG 2 "Selected DE $DE"
 
 # sanitize BROWSER (avoid calling ourselves in particular)


### PR DESCRIPTION
When set, the same mechanism that is used in a flatpak is used, a dbus call to the portal. This is useful for distros with non-flatpak wrapper or sandboxing features which require the same treatment, eg NixOS.

See https://github.com/NixOS/nixpkgs/issues/160923, https://github.com/NixOS/nixpkgs/pull/187293#pullrequestreview-1098471664

note: I have not integrated a fix for open_flatpak not handling files in this, as xdg-open uses an unknown `/bin/sh` not bash and I think the fh selection `exec {targetFileReadFd}< "$targetFile"` I used can't be relied on.